### PR TITLE
 Change web sketch output from uint64 to hex 

### DIFF
--- a/pp_sketch/__init__.py
+++ b/pp_sketch/__init__.py
@@ -3,4 +3,4 @@
 
 '''PopPUNK sketching functions'''
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,6 +51,7 @@ CUDA_OBJS=gpu/dist.cu.o gpu/sketch.cu.o gpu/device_reads.cu.o gpu/gpu_countmin.c
 web: CXX = em++
 # optimised compile options
 # NB turn exceptions back on for testing
+# NB `--closure 1` can be used to reduce size of js file (this minifies variable names!)
 web: CXXFLAGS = -O3 -s ASSERTIONS=1  \
 				-DNOEXCEPT \
 				-DJSON_NOEXCEPTION \

--- a/src/Makefile
+++ b/src/Makefile
@@ -48,11 +48,10 @@ GPU_SKETCH_OBJS=gpu/gpu_api.o
 CUDA_OBJS=gpu/dist.cu.o gpu/sketch.cu.o gpu/device_reads.cu.o gpu/gpu_countmin.cu.o gpu/device_memory.cu.o
 
 # web specific options
-web: CXX = emcc
+web: CXX = em++
 # optimised compile options
 # NB turn exceptions back on for testing
 web: CXXFLAGS = -O3 -s ASSERTIONS=1  \
-				--closure 1 \
 				-DNOEXCEPT \
 				-DJSON_NOEXCEPTION \
 				-s DISABLE_EXCEPTION_CATCHING=1 \
@@ -62,7 +61,7 @@ web: CXXFLAGS = -O3 -s ASSERTIONS=1  \
 				-s USE_ZLIB=1 \
 				-s MODULARIZE=1 \
 				-s "EXPORTED_FUNCTIONS=['_malloc']" \
-				-s 'EXTRA_EXPORTED_RUNTIME_METHODS=["FS"]' \
+				-s 'EXPORTED_RUNTIME_METHODS=["FS"]' \
 				-s EXPORT_NAME=WebSketch \
 				-Wall -Wextra -std=c++14
 web: CPPFLAGS += -DWEB_SKETCH

--- a/src/web/web_sketch.cpp
+++ b/src/web/web_sketch.cpp
@@ -1,8 +1,10 @@
 
 #include <fstream>
 #include <iostream>
+#include <iomanip>
 #include <algorithm> // sort
 #include <string>
+#include <sstream>
 
 #include <emscripten/bind.h>
 using namespace emscripten;
@@ -60,7 +62,14 @@ std::string json_sketch(const std::string file,
     std::tie(kmer_sketch, minhash, densified) =
         sketch(sequence, sketchsize64, kmer_it->second, bbits,
                codon_phased, use_rc, 0, false);
-    sketch_json[std::to_string(kmer_it->first)] = kmer_sketch;
+    std::vector<std::string> kmer_sketch_hex;
+    for (int i = 0; i < kmer_sketch.size(); i++)
+    {
+      std::stringstream stream;
+      stream << "0x" << std::hex << kmer_sketch[i];
+      kmer_sketch_hex.push_back(stream.str());
+    }
+    sketch_json[std::to_string(kmer_it->first)] = kmer_sketch_hex;
 
     minhash_sum += minhash;
     densified |= k_densified; // Densified at any k-mer length


### PR DESCRIPTION
Web sketch is now stored in hexadecimal string format to prevent precision loss.

I had to make some changes to the Makefile to compile successfully with emscripten. 
(`EXTRA_EXPORTED_RUNTIME_METHODS` was [deprecated](https://emscripten.org/docs/introducing_emscripten/release_notes.html?highlight=exported_runtime_methods) with version 2.0.18.
I am not sure why `emcc` was not working for me, I had already used `em++` with the AMR code. Maybe @johnlees could you check if this is also working for you, otherwise we can revert that change)

I have not removed the code that's adding `densified` to the sketch, should I do this as we are not using this attribute anyway?