### PR TITLE
Fix for adding random sequence correction for strand-specific k-mers

### DIFF
--- a/pp_sketch/__main__.py
+++ b/pp_sketch/__main__.py
@@ -9,7 +9,7 @@ Usage:
   sketchlib query sparse <db1> (--kNN <k>|--threshold <max>) [-o <output>] [--accessory] [--adj-random] [--subset <file>] [--cpus <cpus>] [--gpu <gpu>]
   sketchlib query sparse jaccard <db1> --kNN <k> --kmer <k> [-o <output>] [--adj-random] [--subset <file>] [--cpus <cpus>]
   sketchlib join <db1> <db2> -o <output>
-  sketchlib (add|remove) random <db1> [--cpus <cpus>]
+  sketchlib (add|remove) random <db1> [--single-strand] [--cpus <cpus>]
   sketchlib (-h | --help)
   sketchlib (--version)
 


### PR DESCRIPTION
Interface with PopPUNK is already fine, this fix just allows `--single-strand` to be added to the `sketchlib` command line, as expected by https://github.com/bacpop/pp-sketchlib/blob/e8ce624f0b4bbb7316b6b2576f3d9e61b5c60fe5/pp_sketch/__main__.py#L394. Validated the fix with viral data.