### PR TITLE
Fix broken PopPUNK link & replace with valid site

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <!-- badges: end -->
 
 
-Library of sketching functions used by [PopPUNK]([https://www.poppunk.net](https://poppunk.readthedocs.io/). See documentation at http://poppunk.readthedocs.io/en/latest/sketching.html
+Library of sketching functions used by [PopPUNK](https://github.com/bacpop/PopPUNK). See documentation at https://poppunk.bacpop.org/sketching.html#using-pp-sketchlib-directly
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <!-- badges: end -->
 
 
-Library of sketching functions used by [PopPUNK](https://www.poppunk.net>). See documentation at http://poppunk.readthedocs.io/en/latest/sketching.html
+Library of sketching functions used by [PopPUNK]([https://www.poppunk.net](https://poppunk.readthedocs.io/). See documentation at http://poppunk.readthedocs.io/en/latest/sketching.html
 
 ## Installation
 


### PR DESCRIPTION
The link was incorrect (`poppunk.net>`) and also www.poppunk.net is broken, so I replaced it with a link to the top level of the readthedocs site.

Suggestions welcome, or just discard and fix properly :)